### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,7 +5,7 @@ molotov (1.2.1-2) unstable; urgency=medium
   * Add an upstream metadata file
   * Add upstream public key
 
- -- Cézar Augusto de Campos <cezargaiteiro@protonmail.com>  Mon, 26 May 2022 12:50:00 -0300
+ -- Cézar Augusto de Campos <cezargaiteiro@protonmail.com>  Thu, 26 May 2022 12:50:00 -0300
 
 molotov (1.2.1-1) unstable; urgency=medium
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,5 @@
 Bug-Database: "https://github.com/cizordj/molotov/issues"
+Bug-Submit: https://github.com/cizordj/molotov/issues/new
 Cite-As: "Molotov or Molotov USB"
 FAQ: "https://cizordj.codeberg.page/molotov/#faq"
 Other-References: "https://cizordj.codeberg.page/molotov/"


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Fix day-of-week for changelog entry 1.2.1-2. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/molotov/9dc69f54-82ba-4359-9892-2fd64cf65c30.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/9dc69f54-82ba-4359-9892-2fd64cf65c30/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9dc69f54-82ba-4359-9892-2fd64cf65c30/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9dc69f54-82ba-4359-9892-2fd64cf65c30/diffoscope)).
